### PR TITLE
Update GcBuf for type inference / conversion trait issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 keywords = ["str", "string", "cursor", "grapheme", "unicode"]
 license = "MIT/Apache-2.0"
 
+build = "build.rs"
+
 exclude = [
     "update-docs.py",
 ]

--- a/src/grapheme.rs
+++ b/src/grapheme.rs
@@ -522,6 +522,16 @@ impl GcBuf {
     This function *does not* check to ensure the provided string is a single, valid grapheme cluster.
     */
     pub unsafe fn from_string_unchecked(s: String) -> GcBuf {
+        Self::from_string_unchecked_impl(s)
+    }
+
+    #[cfg(has_string_into_boxed_string)]
+    unsafe fn from_string_unchecked_impl(s: String) -> GcBuf {
+        GcBuf(s.into_boxed_str())
+    }
+
+    #[cfg(not(has_string_into_boxed_string))]
+    unsafe fn from_string_unchecked_impl(s: String) -> GcBuf {
         GcBuf(s)
     }
 


### PR DESCRIPTION
The crate did not build using rustc 1.17.0-nightly (824c9ebbd 2017-03-12);
use an explicit conversion instead of relying on `String` -> `Box<str>`
conversion.